### PR TITLE
chore(tooling): add ty extension and GitHub MCP server config

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "ms-python.python",
     "charliermarsh.ruff",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "astral-sh.ty"
   ]
 }

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+	"servers": {
+		"github": {
+			"type": "http",
+			"url": "https://api.githubcopilot.com/mcp/"
+		}
+	},
+	"inputs": []
+}


### PR DESCRIPTION
Adds the `astral-sh.ty` recommended extension and a `.vscode/mcp.json` pointing at the GitHub MCP server (fallback to gh CLI).