### PR TITLE
Reduce Temporal Prometheus metrics ingestion

### DIFF
--- a/services/observability/README.md
+++ b/services/observability/README.md
@@ -61,3 +61,16 @@ Check the `provisioning/dashboards/` directory for pre-configured dashboards.
 - `prometheus.yml`: Scrape configuration
 - `provisioning/datasources/`: Grafana datasource configuration
 - `provisioning/dashboards/`: Dashboard provisioning configuration
+
+### Temporal Metrics Policy
+
+Temporal is scraped once per minute with a post-relabel sample limit of 1,000.
+Prometheus retains workflow completion/timeout, request/error, task-queue
+backlog/lag, worker and poller capacity, and request-latency count/sum signals.
+All other Temporal metric families are dropped before storage, along with
+deployment-specific or unbounded labels such as worker build, partition,
+namespace ID, workflow ID, and run ID.
+
+The service-health dashboard uses `workflow_success` for workflow completions
+and `service_errors` for request errors. Temporal's local endpoint does not
+currently emit a `workflow_failed` metric.

--- a/services/observability/prometheus.yml
+++ b/services/observability/prometheus.yml
@@ -25,9 +25,18 @@ scrape_configs:
 
   # Temporal Server
   - job_name: "temporal"
+    scrape_interval: 1m
+    sample_limit: 1000
     static_configs:
       - targets: ["folium-temporal:8000"]
     metrics_path: "/metrics"
+    metric_relabel_configs:
+      # Keep only workflow health, worker capacity, task-queue, and latency aggregates.
+      - source_labels: [__name__]
+        regex: "(workflow_success|workflow_failed|workflow_timeout|temporal_request_failure(_attempt)?|service_errors|service_error_with_type|service_requests|approximate_backlog_(count|age_seconds)|task_lag_per_tl|temporal_worker_task_slots_(available|used)|temporal_(worker|poller)_start|temporal_workflow_task_queue_poll_empty|temporal_request_latency(_attempt)?_(count|sum))"
+        action: keep
+      - action: labeldrop
+        regex: "(worker_build_id|partition|namespace_id|workflow_id|run_id)"
 
   # PostgreSQL Exporter (optional, if added later)
   # - job_name: 'postgres'

--- a/services/observability/provisioning/dashboards/service-health.json
+++ b/services/observability/provisioning/dashboards/service-health.json
@@ -215,8 +215,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(temporal_workflow_completed_total{job=\"temporal\"}[5m])",
-          "legendFormat": "Successful - {{workflow_type}}",
+          "expr": "rate(workflow_success{job=\"temporal\"}[5m])",
+          "legendFormat": "Workflow completed - {{namespace}} / {{taskqueue}}",
           "refId": "A"
         },
         {
@@ -224,12 +224,12 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "rate(temporal_workflow_failed_total{job=\"temporal\"}[5m])",
-          "legendFormat": "Failed - {{workflow_type}}",
+          "expr": "rate(service_errors{job=\"temporal\"}[5m])",
+          "legendFormat": "Request errors - {{service_name}} / {{operation}}",
           "refId": "B"
         }
       ],
-      "title": "Temporal Workflow Success Rate",
+      "title": "Temporal Workflow Completions and Request Errors",
       "type": "timeseries"
     },
     {


### PR DESCRIPTION
## Summary

- Scrape Temporal once per minute with a 1,000-sample cap.
- Allowlist workflow health, request/error, task-queue, worker/poller capacity, retry, and latency aggregate metrics.
- Drop non-operational families plus unbounded/deployment-specific labels before Prometheus storage.
- Correct the Temporal workflow-health dashboard to query emitted `workflow_success` and `service_errors` signals.

## Measured Result

- Baseline: 7,012 samples per 15-second scrape and 7,017 stored series.
- Filtered policy: 433 post-relabel samples on a one-minute scrape, a 93.8% per-scrape reduction.
- Post-reload window: 288 Temporal series.
- The reduced interval plus filtering lowers effective Temporal sample writes from about 28,048 to 433 per minute, approximately 98.5%.

`metric_relabel_configs` filters after Prometheus fetches `/metrics`; this reduces storage and downstream remote-write ingestion, not the Temporal endpoint payload.

## Validation

- `promtool check config` passed.
- Observability Compose configuration and Grafana dashboard JSON validated.
- Live Prometheus target reported `up`, `scrapeInterval: 1m`, and `scrape_samples_post_metric_relabeling: 433`.
- Retained completion, request-error/request-count, queue backlog/lag, and worker-capacity queries returned data.
- Grafana is receiving the retained metrics.

Closes #37